### PR TITLE
Add personal portfolio pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# [Astro](https://astro.build) Blog Template
+# Personal Portfolio and Blog
 
-[![Screenshot](screenshot.png)](https://astro-blog-template.netlify.app/)
+# [Astro](https://astro.build) based template customized for a personal site.
+This project contains the code for a portfolio and blog that showcases
+research interests, projects and travel photos.
 
 ## 👉 Check out the ✨ [Live Demo](https://astro-blog-template.netlify.app/) ✨
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -65,7 +65,14 @@ const { current = '' } = Astro.props;
 <nav>
   <a class={current === "" ? "selected" : ""} href='/'>home</a>
   <a class={current === "about" ? "selected" : ""} href='/about'>about</a>
+  <a class={current === "research" ? "selected" : ""} href='/research'>research</a>
+  <a class={current === "projects" ? "selected" : ""} href='/projects'>projects</a>
+  <a class={current === "teaching" ? "selected" : ""} href='/teaching'>teaching</a>
+  <a class={current === "hobbies" ? "selected" : ""} href='/hobbies'>hobbies</a>
+  <a class={current === "travel" ? "selected" : ""} href='/travel'>travel</a>
+  <a class={current === "photos" ? "selected" : ""} href='/photos'>photos</a>
   <a class={current === "blog" ? "selected" : ""} href='/blog'>blog</a>
+  <a class={current === "resume" ? "selected" : ""} href='/resume'>resume</a>
   <div class="theme-toggle-container">
     <ThemeToggleButton client:load />
   </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -18,12 +18,9 @@ const permalink = `${Astro.site.href}about`;
         <a href="https://icons8.com/illustrations" target="_blank" rel="noopener">Ouch!</a>
       </figcaption>
     </figure>
-    <p>Text placeholder via <a href="https://jeffsum.com/" target="_blank">Jeffsum</a>.</p>
-    <p>So you two dig up, dig up dinosaurs? What do they got in there? King Kong? My dad once told me, laugh and the world laughs with you, Cry, and I'll give you something to cry about you little bastard! Life finds a way. God creates dinosaurs. God destroys dinosaurs. God creates Man. Man destroys God. Man creates Dinosaurs.</p>
-    <p>You really think you can fly that thing? You know what? It is beets. I've crashed into a beet truck. Forget the fat lady! You're obsessed with the fat lady! Drive us out of here! Is this my espresso machine? Wh-what is-h-how did you get my espresso machine?</p>
-    <p>Hey, you know how I'm, like, always trying to save the planet? Here's my chance. Hey, take a look at the earthlings. Goodbye! I was part of something special. Just my luck, no ice. You're a very talented young man, with your own clever thoughts and ideas. Do you need a manager?</p>
-    <p>Jaguar shark! So tell me - does it really exist? This thing comes fully loaded. AM/FM radio, reclining bucket seats, and... power windows. Yes, Yes, without the oops! You're a very talented young man, with your own clever thoughts and ideas. Do you need a manager?</p>
-    <p>Yes, Yes, without the oops! Do you have any idea how long it takes those cups to decompose. They're using our own satellites against us. And the clock is ticking. Do you have any idea how long it takes those cups to decompose. My dad once told me, laugh and the world laughs with you, Cry, and I'll give you something to cry about you little bastard!</p>
+    <p>Hello! I'm a researcher with a passion for medicine, physiology and neuroscience. This website collects my work, personal projects and travel stories.</p>
+    <p>I enjoy exploring new imaging techniques and collaborating with industry partners on innovative medical devices. When not in the lab you can find me outdoors biking, climbing or rowing.</p>
+    <p>Browse the different sections to find my latest blog posts, teaching activities and a selection of photos from my trips.</p>
   </div>
 </BaseLayout>
 

--- a/src/pages/hobbies.astro
+++ b/src/pages/hobbies.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Hobbies';
+const description = 'What I like to do outside work.';
+const permalink = `${Astro.site.href}hobbies`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="hobbies">
+  <div class="container">
+    <h1>Hobbies</h1>
+    <p>Outside of work I enjoy spending time outdoors and exploring new activities.</p>
+    <ul>
+      <li>Biking, climbing and rowing</li>
+      <li>Trekking and travel</li>
+      <li>Reading and amateur radio</li>
+    </ul>
+  </div>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,16 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 
-const title = 'My Astro Blog';
-const description = 'The perfect starter for your perfect blog.';
+const title = 'Personal Portfolio & Blog';
+const description = 'Research, projects, hobbies and thoughts.';
 const permalink = Astro.site.href;
 ---
 
 <BaseLayout title={title} description={description} permalink={permalink}>
   <div class="home-container">
     <div class="home-copy">
-      <h1>Welcome to your new Astro Blog</h1>
-      <p>Check out the docs on <a href="https://www.github.com/Charca/astro-blog-template" target="_blank" rel="noopener">GitHub</a> to get started.</p>
+      <h1>Welcome</h1>
+      <p>This site collects my research notes, blog posts and adventures.</p>
     </div>
 
     <div class="hero-image-container">

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Photo Gallery';
+const description = 'Pictures from my adventures and projects.';
+const permalink = `${Astro.site.href}photos`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="photos">
+  <div class="container">
+    <h1>Photo Gallery</h1>
+    <p>Embedded albums from Google Photos.</p>
+    <iframe src="https://photos.google.com/share/examplealbum" width="100%" height="600" loading="lazy"></iframe>
+  </div>
+</BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Projects';
+const description = 'Research and industrial projects.';
+const permalink = `${Astro.site.href}projects`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="projects">
+  <div class="container">
+    <h1>Projects</h1>
+    <p>A showcase of selected research and industrial projects.</p>
+    <ul>
+      <li>Project One – imaging pipeline for clinical data</li>
+      <li>Project Two – neural interface prototype</li>
+      <li>Project Three – data analysis toolkit</li>
+    </ul>
+  </div>
+</BaseLayout>

--- a/src/pages/research.astro
+++ b/src/pages/research.astro
@@ -1,0 +1,22 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Research';
+const description = 'Research interests and projects.';
+const permalink = `${Astro.site.href}research`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="research">
+  <div class="container">
+    <h1>Research</h1>
+    <p>This section highlights my current and past research efforts in medicine, neuroscience, and neuroimaging.</p>
+    <h2>Research Interests</h2>
+    <ul>
+      <li>Neuroimaging methods</li>
+      <li>Physiology and neural modelling</li>
+      <li>Medical device development</li>
+    </ul>
+    <h2>Recent Projects</h2>
+    <p>Details about industrial collaborations and academic projects can be listed here.</p>
+  </div>
+</BaseLayout>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Resume';
+const description = 'My professional resume and background.';
+const permalink = `${Astro.site.href}resume`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="resume">
+  <div class="container">
+    <h1>Resume</h1>
+    <p>You can download my full CV as a PDF below or view it online.</p>
+    <p><a href="https://example.com/my-cv.pdf" target="_blank">Download PDF</a></p>
+  </div>
+</BaseLayout>

--- a/src/pages/teaching.astro
+++ b/src/pages/teaching.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Teaching';
+const description = 'Teaching activities in medicine and neuroscience.';
+const permalink = `${Astro.site.href}teaching`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="teaching">
+  <div class="container">
+    <h1>Teaching</h1>
+    <p>I teach courses in medicine, physiology, neuroscience and neuroimaging at undergraduate and graduate level.</p>
+    <h2>Recent Courses</h2>
+    <ul>
+      <li>Introduction to Human Physiology</li>
+      <li>Neuroimaging Techniques</li>
+      <li>Advanced Neuroscience Seminars</li>
+    </ul>
+  </div>
+</BaseLayout>

--- a/src/pages/travel.astro
+++ b/src/pages/travel.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = 'Travel';
+const description = 'Past trips and upcoming adventures.';
+const permalink = `${Astro.site.href}travel`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="travel">
+  <div class="container">
+    <h1>Travel</h1>
+    <p>A log of my past travels, upcoming plans and memorable routes.</p>
+    <h2>Routes</h2>
+    <p>See my tracks on <a href="https://www.wikiloc.com" target="_blank">Wikiloc</a> or <a href="https://www.komoot.com" target="_blank">Komoot</a>.</p>
+    <iframe width="100%" height="400" src="https://www.wikiloc.com/wikiloc/embed.do?id=12345" loading="lazy"></iframe>
+    <h2>Photo Albums</h2>
+    <iframe src="https://photos.google.com/share/examplealbum" width="100%" height="600" loading="lazy"></iframe>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- switch README to a personal portfolio focus
- expand site navigation with research, projects, teaching, hobbies, travel, photos and resume pages
- fill in the about page with short bio text
- customise the home page headline
- add placeholder pages for research, projects, teaching, hobbies, travel, photos and resume

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685454928ba4832fad2e90b7ff7c5ead