### PR TITLE
Improve responsiveness and clean up pages

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <path d="M32 6c-8 0-14 6-14 14v2c-4 0-8 3-8 8v6c-4 0-8 4-8 8v8c0 8 6 14 14 14h32c8 0 14-6 14-14v-8c4 0 8-4 8-8v-6c0-5-4-8-8-8v-2c0-8-6-14-14-14H32z" fill="#f38" stroke="#000" stroke-width="2"/>
+  <text y="52" font-size="52">🧠</text>
 </svg>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -15,7 +15,7 @@ const socialUrl = Astro.site.href + 'assets/social.png'
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
 <!-- Primary Meta Tags -->

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -55,8 +55,17 @@ const { current = '' } = Astro.props;
   }
 
   @media screen and (max-width: 520px) {
+    nav {
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
     .theme-toggle-container {
       margin-right: 1em;
+    }
+
+    a {
+      margin-left: 10px;
     }
   }
 

--- a/src/pages/albums.astro
+++ b/src/pages/albums.astro
@@ -9,7 +9,5 @@ const permalink = `${Astro.site.href}albums`;
 <BaseLayout title={title} description={description} permalink={permalink} current="albums">
   <div class="container">
     <h1>Albums</h1>
-    <p>Embedded albums from Google Photos.</p>
-    <iframe src="https://photos.google.com/share/examplealbum" width="100%" height="600" loading="lazy"></iframe>
   </div>
 </BaseLayout>

--- a/src/pages/personal.astro
+++ b/src/pages/personal.astro
@@ -21,8 +21,6 @@ const permalink = `${Astro.site.href}personal`;
     <p>See my tracks on <a href="https://www.wikiloc.com" target="_blank">Wikiloc</a> or <a href="https://www.komoot.com" target="_blank">Komoot</a>.</p>
     <iframe width="100%" height="400" src="https://www.wikiloc.com/wikiloc/embed.do?id=12345" loading="lazy"></iframe>
     <h2 id="albums">Albums</h2>
-    <p>Embedded albums from Google Photos.</p>
-    <iframe src="https://photos.google.com/share/examplealbum" width="100%" height="600" loading="lazy"></iframe>
     <h2 id="radio">Radio</h2>
     <p>I enjoy experimenting with amateur radio and building simple receivers and transmitters.</p>
   </div>

--- a/src/pages/travel.astro
+++ b/src/pages/travel.astro
@@ -14,6 +14,5 @@ const permalink = `${Astro.site.href}travel`;
     <p>See my tracks on <a href="https://www.wikiloc.com" target="_blank">Wikiloc</a> or <a href="https://www.komoot.com" target="_blank">Komoot</a>.</p>
     <iframe width="100%" height="400" src="https://www.wikiloc.com/wikiloc/embed.do?id=12345" loading="lazy"></iframe>
     <h2>Photo Albums</h2>
-    <iframe src="https://photos.google.com/share/examplealbum" width="100%" height="600" loading="lazy"></iframe>
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add initial scale to viewport
- make nav bar wrap on small screens
- replace favicon with brain emoji
- remove Google Photos embeds from travel, personal and albums pages

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545d00dc68832fbe479bbb068c551b